### PR TITLE
add support for proxy and move most variables to file

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,16 @@
+---
+# if proxy isn't needed, comment out ocp_http_proxy and ocp_noproxy
+ocp_http_proxy: http://10.0.0.5:3128
+ocp_noproxy: vcenter.example.com,.example.com,169.254.169.254,10.0.0.0/16
+rhcos_ova: "{{ ansible_env.HOME }}/rhcos-4.3.8-x86_64-vmware.x86_64.ova"
+dns_server_address: 10.0.0.60
+vcenter_hostname: vcenter.example.com
+template_rhcos: "RHCOS"
+vcenter_datacenter: "Datacenter"
+#vcenter_cluster: "Test Cluster" #NOTE: for future use
+vcenter_network: "VM Network"
+vcenter_datastore: ocp
+base_domain: "example.com"
+cluster_name: ocp
+pull_secret: '<REDACTED>'
+

--- a/install_ocp4_vmware.yaml
+++ b/install_ocp4_vmware.yaml
@@ -1,9 +1,5 @@
 - hosts: localhost
   vars_prompt:
-    - name: cluster_name
-      prompt: "Cluster name"
-      private: no
-
     - name: vcenter_username
       prompt: "VCenter Username"
       private: no
@@ -12,18 +8,6 @@
       prompt: "VCenter Password"
       private: yes
 
-    - name: pull_secret
-      prompt: "Openshift Pull Secret"
-      private: yes
-
-  vars:
-    vcenter_hostname: 192.168.10.253
-    template_rhcos: "RHCOS"
-    vcenter_datacenter: "Datacenter"
-    vcenter_network: "VM Network"
-    vcenter_datastore: "datastore4t"
-    base_domain: "bsb.openshiftdemo.com.br"
-    dns_server_address: 192.168.10.1
   tasks:
   ########### Bastion Tasks #############
 

--- a/templates/install-config.yaml.j2
+++ b/templates/install-config.yaml.j2
@@ -1,5 +1,11 @@
 apiVersion: v1
 baseDomain: {{ base_domain }}
+{% if ocp_http_proxy is defined %}
+proxy:
+  httpProxy: {{ ocp_http_proxy }}
+  httpsProxy: {{ ocp_http_proxy }}
+  noProxy: {{ ocp_noproxy|default(base_domain) }}
+{% endif %}
 compute:
 - hyperthreading: Enabled
   name: worker


### PR DESCRIPTION
while executing this playbook dozens of times I thought that moving most variables to a file would make it easier. I left vcenter credentials as vars_prompt in case user doesn't like to have them on files.

Also added option to deploy on environments requiring proxy server.